### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 		"ext-simplexml": "*",
 		"automattic/jetpack-autoloader": "^3.0 || ^4.0 || ^5.0",
 		"pronamic/wp-http": "^1.2",
-		"woocommerce/action-scheduler": "^3.7",
+		"woocommerce/action-scheduler": "^3.7 || ^4.0",
 		"wp-pay/core": "^4.16"
 	},
 	"require-dev": {
@@ -67,7 +67,7 @@
 		"phpstan/phpstan": "^1.11",
 		"pronamic/pronamic-cli": "^1.1",
 		"pronamic/wp-coding-standards": "^2.2",
-		"roots/wordpress": "^6.4",
+		"roots/wordpress": "^6.8",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"vimeo/psalm": "^5.25",
 		"wp-phpunit/wp-phpunit": "^6.4",

--- a/pronamic-pay-multisafepay.php
+++ b/pronamic-pay-multisafepay.php
@@ -5,7 +5,7 @@
  * Description: Extend the Pronamic Pay plugin with the MultiSafepay gateway to receive payments through a variety of WordPress plugins.
  *
  * Version: 4.6.2
- * Requires at least: 5.9
+ * Requires at least: 6.8
  * Requires PHP: 7.4
  *
  * Author: Pronamic


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.